### PR TITLE
Added issue templates and pull request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+#### Describe the bug
+A clear and concise description of what the bug is.
+
+#### Describe how to reproduce the bug
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+#### Describe the expected behavior
+A clear and concise description of what you expected to happen.
+
+#### Show some screenshots
+If applicable, add screenshots to help explain your problem.
+
+#### Describe the OS you are using
+ - OS: [e.g. iOS, Ubuntu 18.04, Windows 10, ...]
+ - Language: [e.g. C++, Python, ...]
+ - Version [e.g. 3.6.8]
+
+#### Additional context
+Add any other context about the bug here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: feature request
+assignees: ''
+
+---
+
+#### Describe the feature
+Is your feature request related to a problem?
+A clear and concise description of what the problem is. 
+Example: I am always frustrated when [...].
+
+#### Describe the solution you would like
+A clear and concise description of what you want to happen.
+
+#### Describe alternatives you have considered
+A clear and concise description of any alternative solutions or features you have considered.
+
+#### Additional context
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,37 @@
+---
+name: Question
+about: Ask a question if you do not understand something or just want clarifications.
+title: ''
+labels: question
+assignees: ''
+
+---
+
+#### Describe the problem
+I want to do ... in my application, but what I am actually getting is....
+Here is a screenshot that illustrates the problem:
+
+`image.png`
+
+#### Describe what you have already tried
+This is the most simplified version of my code that I have been able to get, which still produces the problem I described above.
+
+    // my code
+    ...
+
+Basically, what the code is doing is....
+Changing ... does not work because it gives the following error:
+
+
+    Some error
+
+
+#### Describe your research
+[The documentation here] mentioned ... but did not provide a clear example of how that is done.
+[This Stack Overflow question] describes a similar problem, but mine is different because....
+
+#### Ask your question
+So my basic question is, how do I...?
+
+#### Additional context
+Add any other context or screenshots about the question here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+#### Reference to a related issue in the repository
+Add a reference to a related issue in the repository.
+
+#### Add a description
+Add a description of the changes proposed in the pull request.
+
+**Some questions to ask**:
+What is this change?
+What does it fix?
+Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version?
+How has it been tested?
+
+#### Mention a member
+Add @mentions of the person or team responsible for reviewing proposed changes.
+
+#### Check the checklist
+
+- [ ] I have performed a self-review of my own code.
+- [ ] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
+- [ ] My changes generate no new warnings.
+- [ ] I have added tests that prove my fix is effective or that my feature works.
+- [ ] New and existing unit tests / travis ci of osi for generating the documentation pass locally with my changes.


### PR DESCRIPTION
#### Reference to a related issue in the repository
This is a general improvement for the workflow of the project which originated from the [issue](https://github.com/OpenSimulationInterface/osi-validation/issues/12) of osi-validation.

#### Add a description
Adding templates for issues and pull requests will reduce the friction and misunderstandings between developers and maintainers. Through a template developers can think in a more detailed way of their feature request, bug or question. The usage of the templates will be now introduced and tested if it will improve the general workflow of the project.

#### Mention a member
@jdsika pls review the issue templates and pull request template for the osi-validation. Suggestion and improvements are welcome :).

#### Check the checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation).
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci of osi for generating the documentation pass locally with my changes.